### PR TITLE
Add CSV-driven configuration with schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # CF_TD
+
+This repository contains configuration and validation utilities for a tower defence prototype.  
+Game balance values are stored in CSV files so that they can be tweaked without code changes.  
+`data_loader.py` demonstrates how to load and validate weapon data according to the design rules.
+
+## Data files
+- `data/Weapon.csv` – weapon parameters with schema checks.
+- `data/Enemy.csv` – basic enemy stats.
+- `data/Tactical.csv` – tactical ability configuration.
+- `data/WaveRecipe.csv` – wave composition examples.
+
+## Running validation
+```
+python - <<'PY'
+from pathlib import Path
+from data_loader import load_weapons
+print(load_weapons(Path('data/Weapon.csv')))
+PY
+```
+
+## Tests
+```
+pytest
+```

--- a/data/Enemy.csv
+++ b/data/Enemy.csv
@@ -1,0 +1,3 @@
+Id,HP,ArmorDR,TypeTags,WeakpointMult,WeakpointArea,Speed,LeakDamage
+Walker,100,0.1,normal,1.5,0.2,1.0,1
+Shield,200,0.5,armored,1.5,0.2,0.8,2

--- a/data/Tactical.csv
+++ b/data/Tactical.csv
@@ -1,0 +1,3 @@
+Id,Radius,Delay,Cooldown,EnergyCost,BaseDamage,SplashCurveId,SpecialRules
+C4,2.5,0.8,18,40,280,default,
+Airstrike,2.5,0.2,35,60,120,default,3-segment

--- a/data/WaveRecipe.csv
+++ b/data/WaveRecipe.csv
@@ -1,0 +1,3 @@
+Wave,Duration,Budget,SpawnList,ElitePack,BossId,ArmorMix,EndRemain
+1,30,100,"Walker:10,Runner:5",0,,0.1,3
+2,35,120,"Walker:15,Shield:3",1,,0.2,3

--- a/data/Weapon.csv
+++ b/data/Weapon.csv
@@ -1,0 +1,3 @@
+Id,Slot,Type,BaseDamage,HeadshotMult,CritMult,DistanceFalloff,ArmorPen,FireRate,Mag,Reload,RefireCD,Range,BulletSpeed,AccBase,AccS,AccK,acc_floor,WeakpointRate_Near,WeakpointRate_Mid,WeakpointRate_Far,TurnRate,MultiLock,pierce_cnt,hit_limit,AOERadius,SplashCurveId,Tags
+AR,Primary,AR,28,1.5,1.35,0.5,0.6,8.5,30,2.0,,100,900,0.8,6,0.03,0.3,0.3,0.2,0.1,90,1,0,1,0,,default
+SR,Primary,SR,180,2.0,1.5,0,0.9,,5,2.5,0.6,150,700,0.9,12,0.02,0.3,0.4,0.3,0.2,60,1,0,1,0,,default

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class Weapon:
+    Id: str
+    Slot: str
+    Type: str
+    BaseDamage: float
+    HeadshotMult: float
+    CritMult: float
+    DistanceFalloff: float
+    ArmorPen: float
+    FireRate: float | None
+    Mag: int
+    Reload: float
+    RefireCD: float | None
+    Range: float
+    BulletSpeed: float
+    AccBase: float
+    AccS: float
+    AccK: float
+    acc_floor: float
+    WeakpointRate_Near: float
+    WeakpointRate_Mid: float
+    WeakpointRate_Far: float
+    TurnRate: float
+    MultiLock: int
+    pierce_cnt: int
+    hit_limit: int
+    AOERadius: float
+    SplashCurveId: str
+    Tags: str
+
+
+def _to_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def _to_int(value: str | None) -> int:
+    if value is None or value == "":
+        return 0
+    return int(float(value))
+
+
+def _validate_weapon(row: dict) -> None:
+    fire_rate = _to_float(row.get("FireRate"))
+    refire_cd = _to_float(row.get("RefireCD"))
+    if (fire_rate is None) == (refire_cd is None):
+        raise ValueError(f"Weapon {row.get('Id')} must define exactly one of FireRate or RefireCD")
+
+    armor_pen = float(row.get("ArmorPen", 0))
+    if not (0.0 <= armor_pen <= 0.9):
+        raise ValueError(f"Weapon {row.get('Id')} ArmorPen {armor_pen} out of range")
+
+    head_mult = float(row.get("HeadshotMult", 0))
+    if not (1.5 <= head_mult <= 2.0):
+        raise ValueError(f"Weapon {row.get('Id')} HeadshotMult {head_mult} out of range")
+
+    crit_mult = float(row.get("CritMult", 0))
+    if not (1.35 <= crit_mult <= 1.5):
+        raise ValueError(f"Weapon {row.get('Id')} CritMult {crit_mult} out of range")
+
+    acc_base = float(row.get("AccBase", 0))
+    acc_floor = float(row.get("acc_floor", 0))
+    if not (0.3 <= acc_floor <= acc_base <= 1.0):
+        raise ValueError(
+            f"Weapon {row.get('Id')} acc values invalid: acc_base={acc_base}, acc_floor={acc_floor}")
+
+    near = float(row.get("WeakpointRate_Near", 0))
+    mid = float(row.get("WeakpointRate_Mid", 0))
+    far = float(row.get("WeakpointRate_Far", 0))
+    if not (near >= mid >= far):
+        raise ValueError(
+            f"Weapon {row.get('Id')} weakpoint rates must be monotonic: {near} >= {mid} >= {far}")
+
+
+def load_weapons(path: Path) -> List[Weapon]:
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        weapons: List[Weapon] = []
+        for row in reader:
+            _validate_weapon(row)
+            weapon = Weapon(
+                Id=row["Id"],
+                Slot=row["Slot"],
+                Type=row["Type"],
+                BaseDamage=float(row["BaseDamage"]),
+                HeadshotMult=float(row["HeadshotMult"]),
+                CritMult=float(row["CritMult"]),
+                DistanceFalloff=float(row["DistanceFalloff"]),
+                ArmorPen=float(row["ArmorPen"]),
+                FireRate=_to_float(row.get("FireRate")),
+                Mag=_to_int(row.get("Mag")),
+                Reload=float(row.get("Reload", 0)),
+                RefireCD=_to_float(row.get("RefireCD")),
+                Range=float(row.get("Range", 0)),
+                BulletSpeed=float(row.get("BulletSpeed", 0)),
+                AccBase=float(row.get("AccBase", 0)),
+                AccS=float(row.get("AccS", 0)),
+                AccK=float(row.get("AccK", 0)),
+                acc_floor=float(row.get("acc_floor", 0)),
+                WeakpointRate_Near=float(row.get("WeakpointRate_Near", 0)),
+                WeakpointRate_Mid=float(row.get("WeakpointRate_Mid", 0)),
+                WeakpointRate_Far=float(row.get("WeakpointRate_Far", 0)),
+                TurnRate=float(row.get("TurnRate", 0)),
+                MultiLock=_to_int(row.get("MultiLock")),
+                pierce_cnt=_to_int(row.get("pierce_cnt")),
+                hit_limit=_to_int(row.get("hit_limit")),
+                AOERadius=float(row.get("AOERadius", 0)),
+                SplashCurveId=row.get("SplashCurveId", ""),
+                Tags=row.get("Tags", ""),
+            )
+            weapons.append(weapon)
+    return weapons
+
+
+# Loaders for other CSVs can be implemented similarly as needed

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+
+from data_loader import load_weapons
+
+
+def test_load_weapons_valid():
+    weapons = load_weapons(Path('data/Weapon.csv'))
+    assert len(weapons) == 2
+    assert weapons[0].Id == 'AR'
+
+
+def test_load_weapons_invalid(tmp_path):
+    csv_path = tmp_path / 'Weapon.csv'
+    csv_path.write_text(
+        'Id,Slot,Type,BaseDamage,HeadshotMult,CritMult,DistanceFalloff,ArmorPen,FireRate,Mag,Reload,RefireCD,Range,BulletSpeed,AccBase,AccS,AccK,acc_floor,WeakpointRate_Near,WeakpointRate_Mid,WeakpointRate_Far,TurnRate,MultiLock,pierce_cnt,hit_limit,AOERadius,SplashCurveId,Tags\n'
+        'Bad,Primary,AR,28,2.5,1.2,0.5,1.2,8.5,30,2.0,,100,900,0.2,6,0.03,0.1,0.1,0.2,0.3,90,1,0,1,0,,default\n'
+    )
+    with pytest.raises(ValueError):
+        load_weapons(csv_path)


### PR DESCRIPTION
## Summary
- add sample CSVs for weapons, enemies, tactical abilities and waves
- implement `data_loader` to validate weapon schema (range, monotonic, xor rules)
- test loader with valid data and failure cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaec49666c8323b0afa728cee4fa1b