### PR TITLE
Add basic tower defense simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # CF_TD
+
+Simple prototype tower defense simulation based on design spec.
+
+## Running
+
+```
+python game.py
+```

--- a/data/Enemy.csv
+++ b/data/Enemy.csv
@@ -1,0 +1,4 @@
+Id,HP,ArmorDR,TypeTags,WeakpointMult,WeakpointArea,Speed,LeakDamage
+Walker,100,0.2,,1.5,0.5,1.0,5
+Shield,200,0.5,,1.5,0.5,0.8,10
+Boss,1000,0.4,Boss,1.5,0.5,0.5,20

--- a/data/Tactical.csv
+++ b/data/Tactical.csv
@@ -1,0 +1,5 @@
+Id,Radius,Delay,Cooldown,EnergyCost,BaseDamage,SplashCurveId,SpecialRules
+C4,2.5,0.8,18,40,280,,
+Airstrike,2.5,0.2,35,60,120,,
+Flash,2.0,0.2,22,35,0,stun
+Smoke,3.0,0.2,28,40,0,slow

--- a/data/WaveRecipe.csv
+++ b/data/WaveRecipe.csv
@@ -1,0 +1,2 @@
+Wave,Duration,Budget,SpawnList,ElitePack,BossId,ArmorMix,EndRemain
+1,30,100,Walker*5|Shield*2|Boss*1,1,Boss,,1

--- a/data/Weapon.csv
+++ b/data/Weapon.csv
@@ -1,0 +1,3 @@
+Id,Slot,Type,BaseDamage,HeadshotMult,CritMult,DistanceFalloff,ArmorPen,FireRate,Mag,Reload,RefireCD,Range,BulletSpeed,AccBase,AccS,AccK,acc_floor,WeakpointRate_Near,WeakpointRate_Mid,WeakpointRate_Far,TurnRate,MultiLock,pierce_cnt,hit_limit,AOERadius,SplashCurveId,Tags
+AR,Primary,AR,28,1.5,1.35,0.5,0.6,8.5,30,2.0,,50,900,0.8,6,0.03,0.3,0.3,0.3,0.3,0,1,0,1,0,,
+SR,Primary,SR,180,2.0,1.5,0,0.9,,5,,0.6,80,700,0.9,12,0.01,0.3,0.4,0.4,0.4,0,1,0,1,0,,

--- a/enemy.py
+++ b/enemy.py
@@ -1,43 +1,51 @@
-import csv
-from dataclasses import dataclass
+"""敌人模块"""
+
+import csv  # 读取CSV文件
+from dataclasses import dataclass  # 数据类装饰器
 
 @dataclass
 class Enemy:
-    id: str
-    hp: float
-    armor_dr: float
-    speed: float
-    leak_damage: float
-    pos: float = 30.0  # starting distance
+    """敌人数据结构"""
+    id: str  # 敌人ID
+    hp: float  # 生命值
+    armor_dr: float  # 护甲减伤比例
+    speed: float  # 移动速度
+    leak_damage: float  # 泄露时对城墙造成的伤害
+    pos: float = 30.0  # 起始距离
 
     def update(self, dt: float):
-        self.pos -= self.speed * dt
+        """根据时间步长更新位置"""
+        self.pos -= self.speed * dt  # 向城墙移动
 
     def apply_damage(self, dmg: float, armor_pen: float):
-        effective = dmg * armor_pen * (1 - self.armor_dr)
-        self.hp -= effective
-        return effective
+        """结算伤害并返回实际造成的伤害"""
+        effective = dmg * armor_pen * (1 - self.armor_dr)  # 实际伤害
+        self.hp -= effective  # 扣除生命值
+        return effective  # 返回实际伤害
 
     @property
     def alive(self) -> bool:
+        """是否存活"""
         return self.hp > 0
 
     @property
     def leaked(self) -> bool:
+        """是否已经到达城墙"""
         return self.pos <= 0 and self.alive
 
     @classmethod
     def from_row(cls, row: dict):
+        """从CSV行构造敌人对象"""
         return cls(
-            id=row['Id'],
-            hp=float(row['HP']),
-            armor_dr=float(row['ArmorDR']),
-            speed=float(row['Speed']),
-            leak_damage=float(row['LeakDamage']),
+            id=row['Id'],  # 敌人ID
+            hp=float(row['HP']),  # 生命值
+            armor_dr=float(row['ArmorDR']),  # 护甲减伤
+            speed=float(row['Speed']),  # 移动速度
+            leak_damage=float(row['LeakDamage']),  # 泄露伤害
         )
 
-
 def load_enemies(path: str) -> dict[str, Enemy]:
-    with open(path, newline='') as f:
-        reader = csv.DictReader(f)
-        return {row['Id']: Enemy.from_row(row) for row in reader}
+    """加载敌人配置表"""
+    with open(path, newline='') as f:  # 打开文件
+        reader = csv.DictReader(f)  # CSV读取器
+        return {row['Id']: Enemy.from_row(row) for row in reader}  # 构造字典返回

--- a/enemy.py
+++ b/enemy.py
@@ -1,0 +1,43 @@
+import csv
+from dataclasses import dataclass
+
+@dataclass
+class Enemy:
+    id: str
+    hp: float
+    armor_dr: float
+    speed: float
+    leak_damage: float
+    pos: float = 30.0  # starting distance
+
+    def update(self, dt: float):
+        self.pos -= self.speed * dt
+
+    def apply_damage(self, dmg: float, armor_pen: float):
+        effective = dmg * armor_pen * (1 - self.armor_dr)
+        self.hp -= effective
+        return effective
+
+    @property
+    def alive(self) -> bool:
+        return self.hp > 0
+
+    @property
+    def leaked(self) -> bool:
+        return self.pos <= 0 and self.alive
+
+    @classmethod
+    def from_row(cls, row: dict):
+        return cls(
+            id=row['Id'],
+            hp=float(row['HP']),
+            armor_dr=float(row['ArmorDR']),
+            speed=float(row['Speed']),
+            leak_damage=float(row['LeakDamage']),
+        )
+
+
+def load_enemies(path: str) -> dict[str, Enemy]:
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        return {row['Id']: Enemy.from_row(row) for row in reader}

--- a/game.py
+++ b/game.py
@@ -1,0 +1,65 @@
+from weapon import load_weapons
+from enemy import load_enemies, Enemy
+from wave import load_waves
+
+DT = 0.1
+
+class Game:
+    def __init__(self):
+        self.weapons = load_weapons('data/Weapon.csv')
+        self.enemies_def = load_enemies('data/Enemy.csv')
+        self.waves = load_waves('data/WaveRecipe.csv')
+        self.wall_hp = 100
+        self.coins = 0
+
+    def spawn_enemy(self, enemy_id: str) -> Enemy:
+        base = self.enemies_def[enemy_id]
+        return Enemy(id=base.id, hp=base.hp, armor_dr=base.armor_dr, speed=base.speed, leak_damage=base.leak_damage)
+
+    def run_wave(self, wave_id: int):
+        recipe = self.waves[wave_id]
+        weapon = self.weapons['AR']
+        enemies: list[Enemy] = []
+        time = 0.0
+        fire_cd = 0.0
+        events = recipe.spawn_events.copy()
+        while time < recipe.duration or enemies:
+            # spawn
+            while events and events[0].time <= time:
+                ev = events.popleft()
+                enemies.append(self.spawn_enemy(ev.enemy_id))
+            # update enemies
+            for e in list(enemies):
+                e.update(DT)
+                if e.leaked:
+                    self.wall_hp -= e.leak_damage
+                    enemies.remove(e)
+                elif not e.alive:
+                    self.coins += 1
+                    enemies.remove(e)
+            if self.wall_hp <= 0:
+                print('Wall destroyed')
+                return
+            # fire weapon
+            if fire_cd <= 0 and enemies:
+                target = min(enemies, key=lambda e: e.pos)
+                dist = target.pos
+                acc = weapon.accuracy(dist)
+                weak_rate = weapon.weakpoint_rate(dist)
+                dmg_weak = weapon.damage_at(dist, True)
+                dmg_body = weapon.damage_at(dist, False)
+                expected = acc * (weak_rate * dmg_weak + (1 - weak_rate) * dmg_body)
+                dealt = target.apply_damage(expected, weapon.armor_pen)
+                fire_cd = 1.0 / weapon.fire_rate if weapon.fire_rate else weapon.refire_cd
+            else:
+                fire_cd -= DT
+            time += DT
+        print(f"Wave {wave_id} complete. Wall HP={self.wall_hp}, coins={self.coins}")
+
+
+def main():
+    g = Game()
+    g.run_wave(1)
+
+if __name__ == '__main__':
+    main()

--- a/game.py
+++ b/game.py
@@ -1,65 +1,72 @@
-from weapon import load_weapons
-from enemy import load_enemies, Enemy
-from wave import load_waves
+"""简易塔防游戏主循环"""
 
-DT = 0.1
+from weapon import load_weapons  # 读取武器配置
+from enemy import load_enemies, Enemy  # 读取敌人配置及敌人类
+from wave import load_waves  # 读取波次配置
+
+DT = 0.1  # 每帧时间步长
 
 class Game:
+    """游戏主类"""
     def __init__(self):
-        self.weapons = load_weapons('data/Weapon.csv')
-        self.enemies_def = load_enemies('data/Enemy.csv')
-        self.waves = load_waves('data/WaveRecipe.csv')
-        self.wall_hp = 100
-        self.coins = 0
+        """初始化游戏数据"""
+        self.weapons = load_weapons('data/Weapon.csv')  # 武器字典
+        self.enemies_def = load_enemies('data/Enemy.csv')  # 敌人模板字典
+        self.waves = load_waves('data/WaveRecipe.csv')  # 波次配置字典
+        self.wall_hp = 100  # 城墙生命值
+        self.coins = 0  # 金币数量
 
     def spawn_enemy(self, enemy_id: str) -> Enemy:
-        base = self.enemies_def[enemy_id]
-        return Enemy(id=base.id, hp=base.hp, armor_dr=base.armor_dr, speed=base.speed, leak_damage=base.leak_damage)
+        """根据ID生成敌人实例"""
+        base = self.enemies_def[enemy_id]  # 获取模板
+        return Enemy(id=base.id, hp=base.hp, armor_dr=base.armor_dr,
+                     speed=base.speed, leak_damage=base.leak_damage)  # 返回复制体
 
     def run_wave(self, wave_id: int):
-        recipe = self.waves[wave_id]
-        weapon = self.weapons['AR']
-        enemies: list[Enemy] = []
-        time = 0.0
-        fire_cd = 0.0
-        events = recipe.spawn_events.copy()
-        while time < recipe.duration or enemies:
+        """运行指定波次"""
+        recipe = self.waves[wave_id]  # 当前波次配置
+        weapon = self.weapons['AR']  # 使用的武器
+        enemies: list[Enemy] = []  # 场上敌人列表
+        time = 0.0  # 当前时间
+        fire_cd = 0.0  # 射击冷却计时
+        events = recipe.spawn_events.copy()  # 剩余刷怪事件
+        while time < recipe.duration or enemies:  # 波次循环
             # spawn
             while events and events[0].time <= time:
-                ev = events.popleft()
-                enemies.append(self.spawn_enemy(ev.enemy_id))
+                ev = events.popleft()  # 获取事件
+                enemies.append(self.spawn_enemy(ev.enemy_id))  # 生成敌人
             # update enemies
             for e in list(enemies):
-                e.update(DT)
+                e.update(DT)  # 更新位置
                 if e.leaked:
-                    self.wall_hp -= e.leak_damage
-                    enemies.remove(e)
+                    self.wall_hp -= e.leak_damage  # 城墙受损
+                    enemies.remove(e)  # 移除敌人
                 elif not e.alive:
-                    self.coins += 1
+                    self.coins += 1  # 击杀奖励
                     enemies.remove(e)
             if self.wall_hp <= 0:
-                print('Wall destroyed')
+                print('Wall destroyed')  # 城墙被摧毁
                 return
             # fire weapon
             if fire_cd <= 0 and enemies:
-                target = min(enemies, key=lambda e: e.pos)
-                dist = target.pos
-                acc = weapon.accuracy(dist)
-                weak_rate = weapon.weakpoint_rate(dist)
-                dmg_weak = weapon.damage_at(dist, True)
-                dmg_body = weapon.damage_at(dist, False)
-                expected = acc * (weak_rate * dmg_weak + (1 - weak_rate) * dmg_body)
-                dealt = target.apply_damage(expected, weapon.armor_pen)
-                fire_cd = 1.0 / weapon.fire_rate if weapon.fire_rate else weapon.refire_cd
+                target = min(enemies, key=lambda e: e.pos)  # 选择最近敌人
+                dist = target.pos  # 目标距离
+                acc = weapon.accuracy(dist)  # 命中率
+                weak_rate = weapon.weakpoint_rate(dist)  # 弱点触发率
+                dmg_weak = weapon.damage_at(dist, True)  # 弱点伤害
+                dmg_body = weapon.damage_at(dist, False)  # 身体伤害
+                expected = acc * (weak_rate * dmg_weak + (1 - weak_rate) * dmg_body)  # 期望伤害
+                dealt = target.apply_damage(expected, weapon.armor_pen)  # 实际伤害
+                fire_cd = 1.0 / weapon.fire_rate if weapon.fire_rate else weapon.refire_cd  # 重置冷却
             else:
-                fire_cd -= DT
-            time += DT
-        print(f"Wave {wave_id} complete. Wall HP={self.wall_hp}, coins={self.coins}")
-
+                fire_cd -= DT  # 冷却递减
+            time += DT  # 时间推进
+        print(f"Wave {wave_id} complete. Wall HP={self.wall_hp}, coins={self.coins}")  # 波次结束
 
 def main():
-    g = Game()
-    g.run_wave(1)
+    """程序入口"""
+    g = Game()  # 创建游戏对象
+    g.run_wave(1)  # 运行第一波
 
 if __name__ == '__main__':
-    main()
+    main()  # 启动游戏

--- a/tactical.py
+++ b/tactical.py
@@ -1,0 +1,30 @@
+import csv
+from dataclasses import dataclass
+
+@dataclass
+class Tactical:
+    id: str
+    radius: float
+    delay: float
+    cooldown: float
+    energy_cost: float
+    base_damage: float
+    special: str
+
+    @classmethod
+    def from_row(cls, row: dict):
+        return cls(
+            id=row['Id'],
+            radius=float(row['Radius']),
+            delay=float(row['Delay']),
+            cooldown=float(row['Cooldown']),
+            energy_cost=float(row['EnergyCost']),
+            base_damage=float(row['BaseDamage']),
+            special=row['SpecialRules'],
+        )
+
+
+def load_tacticals(path: str) -> dict[str, Tactical]:
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        return {row['Id']: Tactical.from_row(row) for row in reader}

--- a/tactical.py
+++ b/tactical.py
@@ -1,30 +1,34 @@
-import csv
-from dataclasses import dataclass
+"""战术技能模块"""
+
+import csv  # 读取CSV文件
+from dataclasses import dataclass  # 数据类装饰器
 
 @dataclass
 class Tactical:
-    id: str
-    radius: float
-    delay: float
-    cooldown: float
-    energy_cost: float
-    base_damage: float
-    special: str
+    """战术技能数据结构"""
+    id: str  # 技能ID
+    radius: float  # 作用半径
+    delay: float  # 施放延迟
+    cooldown: float  # 冷却时间
+    energy_cost: float  # 能量消耗
+    base_damage: float  # 基础伤害
+    special: str  # 特殊规则描述
 
     @classmethod
     def from_row(cls, row: dict):
+        """从CSV行构造战术技能对象"""
         return cls(
-            id=row['Id'],
-            radius=float(row['Radius']),
-            delay=float(row['Delay']),
-            cooldown=float(row['Cooldown']),
-            energy_cost=float(row['EnergyCost']),
-            base_damage=float(row['BaseDamage']),
-            special=row['SpecialRules'],
+            id=row['Id'],  # 技能ID
+            radius=float(row['Radius']),  # 作用半径
+            delay=float(row['Delay']),  # 施放延迟
+            cooldown=float(row['Cooldown']),  # 冷却时间
+            energy_cost=float(row['EnergyCost']),  # 能量消耗
+            base_damage=float(row['BaseDamage']),  # 基础伤害
+            special=row['SpecialRules'],  # 特殊规则
         )
 
-
 def load_tacticals(path: str) -> dict[str, Tactical]:
-    with open(path, newline='') as f:
-        reader = csv.DictReader(f)
-        return {row['Id']: Tactical.from_row(row) for row in reader}
+    """加载战术技能配置表"""
+    with open(path, newline='') as f:  # 打开文件
+        reader = csv.DictReader(f)  # CSV读取器
+        return {row['Id']: Tactical.from_row(row) for row in reader}  # 构造字典返回

--- a/wave.py
+++ b/wave.py
@@ -1,36 +1,41 @@
-import csv
-from dataclasses import dataclass
-from collections import deque
+"""波次配置模块"""
+
+import csv  # 读取CSV文件
+from dataclasses import dataclass  # 数据类装饰器
+from collections import deque  # 双端队列
 
 @dataclass
 class SpawnEvent:
-    time: float
-    enemy_id: str
+    """单次刷怪事件"""
+    time: float  # 触发时间
+    enemy_id: str  # 敌人ID
 
 @dataclass
 class WaveRecipe:
-    wave: int
-    duration: float
-    spawn_events: deque[SpawnEvent]
+    """波次配置数据"""
+    wave: int  # 波次编号
+    duration: float  # 波次持续时间
+    spawn_events: deque[SpawnEvent]  # 刷怪事件队列
 
     @classmethod
     def from_row(cls, row: dict):
-        events = deque()
-        spawn_str = row['SpawnList']
-        t = 0.0
+        """从CSV行构造波次配置"""
+        events = deque()  # 刷怪事件队列
+        spawn_str = row['SpawnList']  # 刷怪描述字符串
+        t = 0.0  # 当前时间
         for part in spawn_str.split('|'):
-            name,count = part.split('*')
+            name, count = part.split('*')  # 敌人ID与数量
             for _ in range(int(count)):
-                events.append(SpawnEvent(time=t, enemy_id=name))
-                t += 1.0
+                events.append(SpawnEvent(time=t, enemy_id=name))  # 添加事件
+                t += 1.0  # 下一次刷怪时间
         return cls(
-            wave=int(row['Wave']),
-            duration=float(row['Duration']),
-            spawn_events=events,
+            wave=int(row['Wave']),  # 波次编号
+            duration=float(row['Duration']),  # 持续时间
+            spawn_events=events,  # 事件队列
         )
 
-
 def load_waves(path: str) -> dict[int, WaveRecipe]:
-    with open(path, newline='') as f:
-        reader = csv.DictReader(f)
-        return {int(row['Wave']): WaveRecipe.from_row(row) for row in reader}
+    """加载波次配置表"""
+    with open(path, newline='') as f:  # 打开文件
+        reader = csv.DictReader(f)  # CSV读取器
+        return {int(row['Wave']): WaveRecipe.from_row(row) for row in reader}  # 构造字典

--- a/wave.py
+++ b/wave.py
@@ -1,0 +1,36 @@
+import csv
+from dataclasses import dataclass
+from collections import deque
+
+@dataclass
+class SpawnEvent:
+    time: float
+    enemy_id: str
+
+@dataclass
+class WaveRecipe:
+    wave: int
+    duration: float
+    spawn_events: deque[SpawnEvent]
+
+    @classmethod
+    def from_row(cls, row: dict):
+        events = deque()
+        spawn_str = row['SpawnList']
+        t = 0.0
+        for part in spawn_str.split('|'):
+            name,count = part.split('*')
+            for _ in range(int(count)):
+                events.append(SpawnEvent(time=t, enemy_id=name))
+                t += 1.0
+        return cls(
+            wave=int(row['Wave']),
+            duration=float(row['Duration']),
+            spawn_events=events,
+        )
+
+
+def load_waves(path: str) -> dict[int, WaveRecipe]:
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        return {int(row['Wave']): WaveRecipe.from_row(row) for row in reader}

--- a/weapon.py
+++ b/weapon.py
@@ -1,0 +1,68 @@
+import csv
+from dataclasses import dataclass
+
+@dataclass
+class Weapon:
+    id: str
+    base_damage: float
+    headshot_mult: float
+    falloff: float
+    armor_pen: float
+    fire_rate: float | None
+    refire_cd: float | None
+    range: float
+    bullet_speed: float
+    acc_base: float
+    acc_s: float
+    acc_k: float
+    acc_floor: float
+    weak_near: float
+    weak_mid: float
+    weak_far: float
+
+    def accuracy(self, distance: float) -> float:
+        if distance <= self.acc_s:
+            acc = self.acc_base
+        else:
+            acc = self.acc_base - self.acc_k * (distance - self.acc_s)
+        return max(self.acc_floor, acc)
+
+    def weakpoint_rate(self, distance: float) -> float:
+        if distance <= 6:
+            return self.weak_near
+        if distance <= 12:
+            return self.weak_mid
+        return self.weak_far
+
+    def damage_at(self, distance: float, weakpoint: bool) -> float:
+        dmg = max(0.0, self.base_damage - distance * self.falloff)
+        if weakpoint:
+            dmg *= self.headshot_mult
+        return dmg
+
+    @classmethod
+    def from_row(cls, row: dict):
+        return cls(
+            id=row['Id'],
+            base_damage=float(row['BaseDamage']),
+            headshot_mult=float(row['HeadshotMult']),
+            falloff=float(row['DistanceFalloff']),
+            armor_pen=float(row['ArmorPen']),
+            fire_rate=float(row['FireRate']) if row['FireRate'] else None,
+            refire_cd=float(row['RefireCD']) if row['RefireCD'] else None,
+            range=float(row['Range']),
+            bullet_speed=float(row['BulletSpeed']),
+            acc_base=float(row['AccBase']),
+            acc_s=float(row['AccS']),
+            acc_k=float(row['AccK']),
+            acc_floor=float(row['acc_floor']),
+            weak_near=float(row['WeakpointRate_Near']),
+            weak_mid=float(row['WeakpointRate_Mid']),
+            weak_far=float(row['WeakpointRate_Far']),
+        )
+
+
+def load_weapons(path: str) -> dict[str, Weapon]:
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        return {row['Id']: Weapon.from_row(row) for row in reader}

--- a/weapon.py
+++ b/weapon.py
@@ -1,68 +1,75 @@
-import csv
-from dataclasses import dataclass
+"""武器系统模块"""
+
+import csv  # 读取CSV数据
+from dataclasses import dataclass  # 使用数据类保存武器信息
 
 @dataclass
 class Weapon:
-    id: str
-    base_damage: float
-    headshot_mult: float
-    falloff: float
-    armor_pen: float
-    fire_rate: float | None
-    refire_cd: float | None
-    range: float
-    bullet_speed: float
-    acc_base: float
-    acc_s: float
-    acc_k: float
-    acc_floor: float
-    weak_near: float
-    weak_mid: float
-    weak_far: float
+    """武器数据结构，存储所有武器参数"""
+    id: str  # 武器ID
+    base_damage: float  # 基础伤害
+    headshot_mult: float  # 爆头倍率
+    falloff: float  # 距离衰减系数
+    armor_pen: float  # 护甲穿透率
+    fire_rate: float | None  # 射速，和refire_cd互斥
+    refire_cd: float | None  # 射击间隔，fire_rate为空时使用
+    range: float  # 射程
+    bullet_speed: float  # 子弹速度
+    acc_base: float  # 基础命中率
+    acc_s: float  # 命中率拐点距离
+    acc_k: float  # 命中率衰减斜率
+    acc_floor: float  # 命中率下限
+    weak_near: float  # 近距离弱点率
+    weak_mid: float  # 中距离弱点率
+    weak_far: float  # 远距离弱点率
 
     def accuracy(self, distance: float) -> float:
+        """根据距离计算命中率"""
         if distance <= self.acc_s:
-            acc = self.acc_base
+            acc = self.acc_base  # 使用基础命中率
         else:
-            acc = self.acc_base - self.acc_k * (distance - self.acc_s)
-        return max(self.acc_floor, acc)
+            acc = self.acc_base - self.acc_k * (distance - self.acc_s)  # 计算衰减后的命中率
+        return max(self.acc_floor, acc)  # 不低于命中下限
 
     def weakpoint_rate(self, distance: float) -> float:
+        """根据距离返回弱点触发率"""
         if distance <= 6:
-            return self.weak_near
+            return self.weak_near  # 近距离
         if distance <= 12:
-            return self.weak_mid
-        return self.weak_far
+            return self.weak_mid  # 中距离
+        return self.weak_far  # 远距离
 
     def damage_at(self, distance: float, weakpoint: bool) -> float:
-        dmg = max(0.0, self.base_damage - distance * self.falloff)
+        """计算指定距离的伤害，weakpoint 表示是否命中弱点"""
+        dmg = max(0.0, self.base_damage - distance * self.falloff)  # 距离衰减后的伤害
         if weakpoint:
-            dmg *= self.headshot_mult
+            dmg *= self.headshot_mult  # 弱点倍率
         return dmg
 
     @classmethod
     def from_row(cls, row: dict):
+        """从CSV行构造武器对象"""
         return cls(
-            id=row['Id'],
-            base_damage=float(row['BaseDamage']),
-            headshot_mult=float(row['HeadshotMult']),
-            falloff=float(row['DistanceFalloff']),
-            armor_pen=float(row['ArmorPen']),
-            fire_rate=float(row['FireRate']) if row['FireRate'] else None,
-            refire_cd=float(row['RefireCD']) if row['RefireCD'] else None,
-            range=float(row['Range']),
-            bullet_speed=float(row['BulletSpeed']),
-            acc_base=float(row['AccBase']),
-            acc_s=float(row['AccS']),
-            acc_k=float(row['AccK']),
-            acc_floor=float(row['acc_floor']),
-            weak_near=float(row['WeakpointRate_Near']),
-            weak_mid=float(row['WeakpointRate_Mid']),
-            weak_far=float(row['WeakpointRate_Far']),
+            id=row['Id'],  # 武器ID
+            base_damage=float(row['BaseDamage']),  # 基础伤害
+            headshot_mult=float(row['HeadshotMult']),  # 爆头倍率
+            falloff=float(row['DistanceFalloff']),  # 距离衰减
+            armor_pen=float(row['ArmorPen']),  # 护甲穿透率
+            fire_rate=float(row['FireRate']) if row['FireRate'] else None,  # 射速
+            refire_cd=float(row['RefireCD']) if row['RefireCD'] else None,  # 射击间隔
+            range=float(row['Range']),  # 射程
+            bullet_speed=float(row['BulletSpeed']),  # 子弹速度
+            acc_base=float(row['AccBase']),  # 基础命中率
+            acc_s=float(row['AccS']),  # 命中率拐点距离
+            acc_k=float(row['AccK']),  # 命中率衰减斜率
+            acc_floor=float(row['acc_floor']),  # 命中率下限
+            weak_near=float(row['WeakpointRate_Near']),  # 近距弱点率
+            weak_mid=float(row['WeakpointRate_Mid']),  # 中距弱点率
+            weak_far=float(row['WeakpointRate_Far']),  # 远距弱点率
         )
 
-
 def load_weapons(path: str) -> dict[str, Weapon]:
-    with open(path, newline='') as f:
-        reader = csv.DictReader(f)
-        return {row['Id']: Weapon.from_row(row) for row in reader}
+    """加载武器配置表"""
+    with open(path, newline='') as f:  # 打开文件
+        reader = csv.DictReader(f)  # CSV读取器
+        return {row['Id']: Weapon.from_row(row) for row in reader}  # 构造武器字典


### PR DESCRIPTION
## Summary
- Add weapon, enemy, wave, and tactical data-driven classes
- Provide sample CSV data and minimal game loop
- Include README with run instructions

## Testing
- `python game.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaf8b2cb1c8323afddd026b447fc9f