### PR TITLE
Add bullet-based damage simulation

### DIFF
--- a/enemy.py
+++ b/enemy.py
@@ -1,0 +1,23 @@
+class Enemy:
+    """Represents an enemy target with health and optional armor."""
+
+    def __init__(self, hp, armor=0.0):
+        self.hp = hp
+        self.armor = armor
+
+    def apply_damage(self, damage):
+        """Apply damage to the enemy and return remaining HP.
+
+        Parameters
+        ----------
+        damage: float
+            The amount of damage to subtract from the enemy's HP.
+
+        Returns
+        -------
+        float
+            The remaining HP after damage is applied. HP will not drop below
+            zero.
+        """
+        self.hp = max(self.hp - damage, 0)
+        return self.hp

--- a/game.py
+++ b/game.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from weapon import Weapon
+from enemy import Enemy
+
+
+@dataclass
+class Game:
+    """Simple game loop that processes weapon fire against an enemy."""
+
+    weapon: Weapon
+    enemy: Enemy
+
+    def loop(self):
+        """Simulate a single bullet fired from the weapon at the enemy.
+
+        The method uses the weapon's :meth:`hit` to determine if the bullet
+        lands and whether it strikes a weakpoint. Damage is calculated per
+        bullet and armour is taken into account. The enemy's remaining HP is
+        returned for external feedback (e.g., to show "hit" or "headshot" messages).
+
+        Returns
+        -------
+        dict
+            A dictionary containing the results of the shot with the keys:
+            ``hit`` (bool), ``weakpoint`` (bool), ``damage`` (float) and
+            ``enemy_hp`` (float).
+        """
+        hit, weakpoint = self.weapon.hit()
+        if not hit:
+            remaining = self.enemy.apply_damage(0)
+            return {"hit": False, "weakpoint": False, "damage": 0.0, "enemy_hp": remaining}
+
+        damage = self.weapon.damage()
+        if weakpoint:
+            damage *= self.weapon.weakpoint_multiplier()
+
+        damage = max(damage - getattr(self.enemy, "armor", 0), 0)
+        remaining = self.enemy.apply_damage(damage)
+
+        return {"hit": True, "weakpoint": weakpoint, "damage": damage, "enemy_hp": remaining}

--- a/weapon.py
+++ b/weapon.py
@@ -1,0 +1,55 @@
+import random
+
+class Weapon:
+    """Represents a weapon that fires individual bullets.
+
+    Parameters
+    ----------
+    damage: float
+        Base damage dealt by each bullet.
+    accuracy: float
+        Probability in the range [0, 1] that a bullet hits the target.
+    weakpoint_rate: float
+        Probability in the range [0, 1] that a hit bullet strikes a weakpoint.
+    weakpoint_multiplier: float, optional
+        Damage multiplier applied when a weakpoint is hit. Defaults to 2.
+    """
+
+    def __init__(self, damage, accuracy, weakpoint_rate, weakpoint_multiplier=2.0):
+        self._damage = damage
+        self._accuracy = accuracy
+        self._weakpoint_rate = weakpoint_rate
+        self._weakpoint_multiplier = weakpoint_multiplier
+
+    def damage(self):
+        """Return base damage of a bullet."""
+        return self._damage
+
+    def accuracy(self):
+        """Return the accuracy of the weapon."""
+        return self._accuracy
+
+    def weakpoint_rate(self):
+        """Return probability of hitting a weakpoint on hit."""
+        return self._weakpoint_rate
+
+    def weakpoint_multiplier(self):
+        """Return damage multiplier applied on weakpoint hit."""
+        return self._weakpoint_multiplier
+
+    def hit(self):
+        """Determine whether a bullet hits and if it strikes a weakpoint.
+
+        Returns
+        -------
+        tuple(bool, bool)
+            A tuple ``(hit, weakpoint)`` where ``hit`` indicates whether the
+            bullet hit the target and ``weakpoint`` indicates whether the hit
+            was on a weakpoint. ``weakpoint`` is ``False`` when ``hit`` is
+            ``False``.
+        """
+        is_hit = random.random() <= self.accuracy()
+        is_weakpoint = False
+        if is_hit:
+            is_weakpoint = random.random() <= self.weakpoint_rate()
+        return is_hit, is_weakpoint


### PR DESCRIPTION
## Summary
- implement probabilistic `Weapon.hit` including weakpoint checks
- compute per-bullet damage in `Game.loop` with weakpoint and armor handling
- return remaining HP from `Enemy.apply_damage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3b8736088323995756dd851d5ced