### PR TITLE
Implement tactical skills and enemy status effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # CF_TD
+
+Simple demo showing tactical skill casting with energy and cooldown management.
+
+## Running tests
+
+```
+pytest
+```

--- a/game.py
+++ b/game.py
@@ -1,0 +1,108 @@
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Any
+
+
+@dataclass
+class Skill:
+    """Data for a tactical skill."""
+    id: str
+    energy_cost: float
+    cooldown: float
+    damage: float = 0
+    stun_duration: float = 0
+    slow_duration: float = 0
+    slow_multiplier: float = 1.0
+
+
+class Enemy:
+    """Basic enemy supporting status effects."""
+
+    def __init__(self, hp: float = 100, speed: float = 1.0) -> None:
+        self.hp = hp
+        self.base_speed = speed
+        # status name -> data dict with remaining duration and params
+        self.statuses: Dict[str, Dict[str, Any]] = {}
+
+    def take_damage(self, amount: float) -> None:
+        self.hp = max(0, self.hp - amount)
+
+    def apply_status(self, name: str, duration: float, **params: Any) -> None:
+        """Apply a named status effect with given duration and optional params."""
+        self.statuses[name] = {"duration": duration, **params}
+
+    def update(self, dt: float) -> None:
+        """Update all active status effects, reducing remaining durations."""
+        expired = []
+        for name, data in self.statuses.items():
+            data["duration"] -= dt
+            if data["duration"] <= 0:
+                expired.append(name)
+        for name in expired:
+            del self.statuses[name]
+
+    @property
+    def stunned(self) -> bool:
+        return "stun" in self.statuses
+
+    @property
+    def speed(self) -> float:
+        if self.stunned:
+            return 0.0
+        multiplier = 1.0
+        slow = self.statuses.get("slow")
+        if slow:
+            multiplier *= slow.get("multiplier", 1.0)
+        return self.base_speed * multiplier
+
+
+class Game:
+    """Game container tracking energy and skill cooldowns."""
+
+    def __init__(self, energy_max: float = 100, energy_recovery: float = 10.0) -> None:
+        self.energy_max = energy_max
+        self.energy_recovery = energy_recovery
+        self.energy = energy_max
+        self.tacticals: Dict[str, Skill] = {}
+        self.cooldowns: Dict[str, float] = {}
+
+    def load_tacticals(self, path: str) -> None:
+        """Load tactical skill definitions from a JSON file."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        for entry in data:
+            skill = Skill(**entry)
+            self.tacticals[skill.id] = skill
+            self.cooldowns.setdefault(skill.id, 0)
+
+    def cast_tactical(self, skill_id: str, enemies: List[Enemy]) -> bool:
+        """Attempt to cast a tactical skill on the provided enemies.
+
+        Returns True if the skill was cast successfully, otherwise False.
+        """
+        skill = self.tacticals.get(skill_id)
+        if not skill:
+            return False
+        # Check energy and cooldown
+        if self.energy < skill.energy_cost or self.cooldowns.get(skill_id, 0) > 0:
+            return False
+        # Spend energy and set cooldown
+        self.energy -= skill.energy_cost
+        self.cooldowns[skill_id] = skill.cooldown
+
+        # Apply effects to enemies
+        for enemy in enemies:
+            if skill.damage:
+                enemy.take_damage(skill.damage)
+            if skill.stun_duration:
+                enemy.apply_status("stun", skill.stun_duration)
+            if skill.slow_duration and skill.slow_multiplier < 1:
+                enemy.apply_status("slow", skill.slow_duration, multiplier=skill.slow_multiplier)
+        return True
+
+    def update(self, dt: float) -> None:
+        """Recover energy and decrement skill cooldowns."""
+        self.energy = min(self.energy_max, self.energy + self.energy_recovery * dt)
+        for skill_id, cd in list(self.cooldowns.items()):
+            if cd > 0:
+                self.cooldowns[skill_id] = max(0, cd - dt)

--- a/skills.json
+++ b/skills.json
@@ -1,0 +1,17 @@
+[
+    {
+        "id": "fireball",
+        "energy_cost": 20,
+        "cooldown": 3,
+        "damage": 50
+    },
+    {
+        "id": "stun",
+        "energy_cost": 30,
+        "cooldown": 5,
+        "damage": 10,
+        "stun_duration": 2,
+        "slow_duration": 3,
+        "slow_multiplier": 0.5
+    }
+]

--- a/tests/test_tacticals.py
+++ b/tests/test_tacticals.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+import unittest
+
+from game import Game, Enemy
+
+
+class TestTacticals(unittest.TestCase):
+    def setUp(self):
+        self.game = Game()
+        path = Path(__file__).resolve().parent.parent / "skills.json"
+        self.game.load_tacticals(path)
+
+    def test_cast_damage_and_cooldown(self):
+        enemies = [Enemy()]
+        self.game.energy = 50
+        result = self.game.cast_tactical("fireball", enemies)
+        self.assertTrue(result)
+        self.assertEqual(enemies[0].hp, 50)
+        self.assertGreater(self.game.cooldowns["fireball"], 0)
+        self.assertEqual(self.game.energy, 30)
+
+    def test_cast_stun_and_slow(self):
+        enemy = Enemy()
+        self.game.energy = 100
+        self.assertTrue(self.game.cast_tactical("stun", [enemy]))
+        self.assertTrue(enemy.stunned)
+        self.assertIn("slow", enemy.statuses)
+
+    def test_update_energy_and_cooldown(self):
+        self.game.energy = 0
+        self.game.update(1.0)
+        self.assertEqual(self.game.energy, min(self.game.energy_max, 10))
+        self.game.cooldowns["fireball"] = 1.0
+        self.game.update(0.5)
+        self.assertAlmostEqual(self.game.cooldowns["fireball"], 0.5)
+
+    def test_enemy_status_decay(self):
+        enemy = Enemy()
+        enemy.apply_status("slow", 1.0, multiplier=0.5)
+        enemy.apply_status("stun", 0.5)
+        enemy.update(0.5)
+        self.assertNotIn("stun", enemy.statuses)
+        enemy.update(0.5)
+        self.assertNotIn("slow", enemy.statuses)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `Game` class that loads tactical skills, tracks energy and cooldown, and applies skill effects.
- Extend `Enemy` to support damage, stun, and slow status effects with decay over time.
- Provide basic skills data and tests covering casting, energy regen, cooldowns, and status decay.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b82cabc8323a155ec1fc8a03653